### PR TITLE
【リファクタリング】mutation実行後のtoast表示の変更

### DIFF
--- a/web/src/features/service/templates/ServiceMenuModal/RebuildModalBody.tsx
+++ b/web/src/features/service/templates/ServiceMenuModal/RebuildModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetServicesDocument, useRebuildServiceMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 
 type Props = {
@@ -15,29 +14,26 @@ export function RebuildModalBody({ path, onClose }: Props) {
       path: path,
     },
     onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetServicesDocument],
-  });
-
-  const onRebuild = async () => {
-    try {
-      await rebuild();
       toast({
         title: "再構築しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetServicesDocument],
+  });
+
+  const onRebuild = async () => {
+    await rebuild();
   };
 
   return (

--- a/web/src/features/service/templates/ServiceMenuModal/RestartModalBody.tsx
+++ b/web/src/features/service/templates/ServiceMenuModal/RestartModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetServicesDocument, useRestartServiceMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 
 type Props = {
@@ -15,29 +14,26 @@ export function RestartModalBody({ path, onClose }: Props) {
       path: path,
     },
     onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetServicesDocument],
-  });
-
-  const onRestart = async () => {
-    try {
-      await restart();
       toast({
         title: "再起動しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetServicesDocument],
+  });
+
+  const onRestart = async () => {
+    await restart();
   };
 
   return (

--- a/web/src/features/service/templates/ServiceMenuModal/StartModalBody.tsx
+++ b/web/src/features/service/templates/ServiceMenuModal/StartModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetServicesDocument, useStartServiceMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 
 type Props = {
@@ -15,29 +14,26 @@ export function StartModalBody({ path, onClose }: Props) {
       path: path,
     },
     onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetServicesDocument],
-  });
-
-  const onStart = async () => {
-    try {
-      await start();
       toast({
         title: "起動しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetServicesDocument],
+  });
+
+  const onStart = async () => {
+    await start();
   };
 
   return (

--- a/web/src/features/service/templates/ServiceMenuModal/StopModalBody.tsx
+++ b/web/src/features/service/templates/ServiceMenuModal/StopModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetServicesDocument, useStopServiceMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 
 type Props = {
@@ -15,29 +14,26 @@ export function StopModalBody({ path, onClose }: Props) {
       path: path,
     },
     onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetServicesDocument],
-  });
-
-  const onStop = async () => {
-    try {
-      await stop();
       toast({
         title: "停止しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetServicesDocument],
+  });
+
+  const onStop = async () => {
+    await stop();
   };
 
   return (

--- a/web/src/features/storage/hooks.tsx
+++ b/web/src/features/storage/hooks.tsx
@@ -1,5 +1,9 @@
-import { useDownloadFilesMutation } from "@/gql/graphql";
+import {
+  DownloadFilesMutationVariables,
+  useDownloadFilesMutation,
+} from "@/gql/graphql";
 import { client } from "@/pages/_app";
+import { BaseMutationOptions } from "@apollo/client";
 import { DocumentNode } from "graphql";
 import { useRouter } from "next/router";
 
@@ -26,12 +30,18 @@ export function useUpload() {
 }
 
 type DownloadProps = {
-  keys: string[];
+  variables: DownloadFilesMutationVariables;
+  onCompleted?: BaseMutationOptions["onCompleted"];
+  onError?: BaseMutationOptions["onError"];
 };
 
-export function useDownload({ keys }: DownloadProps) {
+export function useDownload({
+  variables,
+  onCompleted,
+  onError,
+}: DownloadProps) {
   return useDownloadFilesMutation({
-    variables: { keys: keys },
+    variables: variables,
     onCompleted(data) {
       if (data) {
         const blob = new Blob([Buffer.from(data.downloadFiles.data, "base64")]);
@@ -41,6 +51,10 @@ export function useDownload({ keys }: DownloadProps) {
         link.click();
         link.remove();
       }
+      onCompleted?.(data);
+    },
+    onError(e) {
+      onError?.(e);
     },
   });
 }

--- a/web/src/features/storage/pages/StoragePathPage.tsx
+++ b/web/src/features/storage/pages/StoragePathPage.tsx
@@ -4,7 +4,6 @@ import Error from "next/error";
 import { FileTileViews } from "../templates/FileTileViews";
 import { useCallback, useContext } from "react";
 import { useDropzone } from "react-dropzone";
-import { ApolloError } from "@apollo/client";
 import { Loading } from "@/components/parts/Loading";
 import { ManagementFileBar } from "../templates/ManagementFileBar";
 import { useGetPath, useGetQueryParam, useUpload } from "../hooks";
@@ -23,31 +22,33 @@ export function StoragePathPage() {
       name: name,
     },
   });
-  const upload = useUpload();
+  const upload = useUpload({
+    onCompleted() {
+      toast({
+        title: "アップロードしました.",
+        status: "success",
+        duration: 5000,
+      });
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
 
   const onDrop = useCallback(
     async (files: File[]) => {
-      try {
-        await upload({
+      await upload({
+        variables: {
           key: path,
           files: files,
-          refetchQueries: [GetFilesDocument],
-        });
-        toast({
-          title: "アップロードしました.",
-          status: "success",
-          duration: 5000,
-        });
-      } catch (e) {
-        if (e instanceof ApolloError) {
-          toast({
-            title: "エラーが発生しました.",
-            description: e.message,
-            status: "error",
-            duration: 5000,
-          });
-        }
-      }
+        },
+      });
     },
     [path, data]
   );

--- a/web/src/features/storage/templates/DirMenuModal/DefaultModalBody.tsx
+++ b/web/src/features/storage/templates/DirMenuModal/DefaultModalBody.tsx
@@ -12,7 +12,6 @@ import { SelectedFileKeysContext } from "../../provides/SelectedFileKeysProvider
 import { FiDownload, FiTrash } from "react-icons/fi";
 import { IoMdCopy } from "react-icons/io";
 import { useDownload } from "../../hooks";
-import { ApolloError } from "@apollo/client";
 import { Loading } from "@/components/parts/Loading";
 
 type Props = {
@@ -28,7 +27,26 @@ export function DefaultModalBody({ setStatus, onClose }: Props) {
   const selectedFileKeysContext = useContext(SelectedFileKeysContext);
 
   const [download, { loading }] = useDownload({
-    keys: selectedFileKeysContext.selectedFileKeys,
+    variables: {
+      keys: selectedFileKeysContext.selectedFileKeys,
+    },
+    onCompleted() {
+      toast({
+        title: "ダウンロードしました.",
+        status: "success",
+        duration: 5000,
+      });
+      onSetSelectMode();
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
   });
 
   const onSetSelectMode = () => {
@@ -42,25 +60,7 @@ export function DefaultModalBody({ setStatus, onClose }: Props) {
   };
 
   const onDownload = async () => {
-    try {
-      await download();
-      toast({
-        title: "ダウンロードしました.",
-        status: "success",
-        duration: 5000,
-      });
-      onSetSelectMode();
-      onClose();
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+    await download();
   };
 
   const onDestroyToken = () => {

--- a/web/src/features/storage/templates/DirMenuModal/RemoveModalBody.tsx
+++ b/web/src/features/storage/templates/DirMenuModal/RemoveModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetFilesDocument, useRemoveFilesMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 import { useContext } from "react";
 import { SelectedFileKeysContext } from "../../provides/SelectedFileKeysProvider";
@@ -10,37 +9,33 @@ type Props = {
 
 export function RemoveModalBody({ onClose }: Props) {
   const selectedFileKeysContext = useContext(SelectedFileKeysContext);
-
-  const [remove] = useRemoveFilesMutation({
-    onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetFilesDocument],
-  });
   const toast = useToast();
 
-  const onRemove = async () => {
-    try {
-      await remove({
-        variables: {
-          keys: selectedFileKeysContext.selectedFileKeys,
-        },
-      });
+  const [remove] = useRemoveFilesMutation({
+    variables: {
+      keys: selectedFileKeysContext.selectedFileKeys,
+    },
+    onCompleted() {
       toast({
         title: "削除しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
+
+  const onRemove = async () => {
+    await remove();
   };
 
   return (

--- a/web/src/features/storage/templates/DirMenuModal/UploadModalBody.tsx
+++ b/web/src/features/storage/templates/DirMenuModal/UploadModalBody.tsx
@@ -2,7 +2,6 @@ import { Button, Circle, Icon, Text, VStack, useToast } from "@chakra-ui/react";
 import { useCallback } from "react";
 import { MdFileUpload } from "react-icons/md";
 import { useGetPath, useUpload } from "../../hooks";
-import { ApolloError } from "@apollo/client";
 import { useDropzone } from "react-dropzone";
 import { GetFilesDocument } from "@/gql/graphql";
 
@@ -14,34 +13,34 @@ export function UploadModalBody({ onClose }: Props) {
   const path = useGetPath();
   const toast = useToast();
 
-  const upload = useUpload();
+  const upload = useUpload({
+    onCompleted() {
+      toast({
+        title: "アップロードしました.",
+        status: "success",
+        duration: 5000,
+      });
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
 
   const onDrop = useCallback(
     async (files: File[]) => {
-      try {
-        await upload({
+      await upload({
+        variables: {
           key: path,
           files: files,
-          onCompleted() {
-            onClose();
-          },
-          refetchQueries: [GetFilesDocument],
-        });
-        toast({
-          title: "アップロードしました.",
-          status: "success",
-          duration: 5000,
-        });
-      } catch (e) {
-        if (e instanceof ApolloError) {
-          toast({
-            title: "エラーが発生しました.",
-            description: e.message,
-            status: "error",
-            duration: 5000,
-          });
-        }
-      }
+        },
+      });
     },
     [path]
   );

--- a/web/src/features/storage/templates/FileMenuModal/CopyModalBody.tsx
+++ b/web/src/features/storage/templates/FileMenuModal/CopyModalBody.tsx
@@ -1,4 +1,3 @@
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, useToast } from "@chakra-ui/react";
 import { useState } from "react";
 import { DirList } from "../DirList";
@@ -12,43 +11,39 @@ type Props = {
 
 export function CopyModalBody({ name, onClose }: Props) {
   const path = useGetPath();
+  const toast = useToast();
 
   const [key, setKey] = useState(path);
   const [copy] = useCopyFileMutation({
-    onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetFilesDocument],
-  });
-  const toast = useToast();
-
-  const onCopy = async () => {
-    try {
-      await copy({
-        variables: {
-          input: [
-            {
-              key: `${path}/${name}`,
-              destination: `${key}/${name}`,
-            },
-          ],
+    variables: {
+      input: [
+        {
+          key: `${path}/${name}`,
+          destination: `${key}/${name}`,
         },
-      });
+      ],
+    },
+    onCompleted() {
       toast({
         title: "コピーしました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
+
+  const onCopy = async () => {
+    await copy();
   };
 
   return (

--- a/web/src/features/storage/templates/FileMenuModal/DefaultModalBody.tsx
+++ b/web/src/features/storage/templates/FileMenuModal/DefaultModalBody.tsx
@@ -6,7 +6,6 @@ import { BsPencil } from "react-icons/bs";
 import { LuFileOutput } from "react-icons/lu";
 import { IoMdCopy } from "react-icons/io";
 import { useDownload } from "../../hooks";
-import { ApolloError } from "@apollo/client";
 import { Loading } from "@/components/parts/Loading";
 
 type Props = {
@@ -17,29 +16,30 @@ type Props = {
 
 export function DefaultModalBody({ filekey, setStatus, onClose }: Props) {
   const [download, { loading }] = useDownload({
-    keys: [filekey],
-  });
-  const toast = useToast();
-
-  const onDownload = async () => {
-    try {
-      await download();
+    variables: {
+      keys: [filekey],
+    },
+    onCompleted() {
       toast({
         title: "ダウンロードしました.",
         status: "success",
         duration: 5000,
       });
       onClose();
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+  });
+  const toast = useToast();
+
+  const onDownload = async () => {
+    await download();
   };
 
   return (

--- a/web/src/features/storage/templates/FileMenuModal/MoveModalBody.tsx
+++ b/web/src/features/storage/templates/FileMenuModal/MoveModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetFilesDocument, useMoveFileMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, useToast } from "@chakra-ui/react";
 import { useState } from "react";
 import { DirList } from "../DirList";
@@ -12,43 +11,39 @@ type Props = {
 
 export function MoveModalBody({ name, onClose }: Props) {
   const path = useGetPath();
+  const toast = useToast();
 
   const [key, setKey] = useState(path);
   const [move] = useMoveFileMutation({
-    onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetFilesDocument],
-  });
-  const toast = useToast();
-
-  const onMove = async () => {
-    try {
-      await move({
-        variables: {
-          input: [
-            {
-              key: `${path}/${name}`,
-              destination: `${key}/${name}`,
-            },
-          ],
+    variables: {
+      input: [
+        {
+          key: `${path}/${name}`,
+          destination: `${key}/${name}`,
         },
-      });
+      ],
+    },
+    onCompleted() {
       toast({
         title: "移動しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
+
+  const onMove = async () => {
+    await move();
   };
 
   return (

--- a/web/src/features/storage/templates/FileMenuModal/RemoveModalBody.tsx
+++ b/web/src/features/storage/templates/FileMenuModal/RemoveModalBody.tsx
@@ -1,5 +1,4 @@
 import { GetFilesDocument, useRemoveFilesMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { Button, HStack, Text, useToast } from "@chakra-ui/react";
 
 type Props = {
@@ -8,33 +7,31 @@ type Props = {
 };
 
 export function RemoveModalBody({ filekey, onClose }: Props) {
+  const toast = useToast();
+
   const [remove] = useRemoveFilesMutation({
     variables: { keys: [filekey] },
     onCompleted() {
-      onClose();
-    },
-    refetchQueries: [GetFilesDocument],
-  });
-  const toast = useToast();
-
-  const onRemove = async () => {
-    try {
-      await remove();
       toast({
         title: "削除しました.",
         status: "success",
         duration: 5000,
       });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+      onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
+    },
+    refetchQueries: [GetFilesDocument],
+  });
+
+  const onRemove = async () => {
+    await remove();
   };
 
   return (

--- a/web/src/features/storage/templates/MakeDirForm/MakeDirForm.tsx
+++ b/web/src/features/storage/templates/MakeDirForm/MakeDirForm.tsx
@@ -11,7 +11,6 @@ import { MakeDirFormSchema, makeDirFormSchema } from "./schema";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { GetFilesDocument, useMakeDirMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { useGetPath } from "../../hooks";
 
 type Props = {
@@ -24,7 +23,20 @@ export function MakeDirForm({ onClose }: Props) {
 
   const [make] = useMakeDirMutation({
     onCompleted() {
+      toast({
+        title: "作成しました.",
+        status: "success",
+        duration: 5000,
+      });
       onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
     },
     refetchQueries: [GetFilesDocument],
   });
@@ -37,27 +49,11 @@ export function MakeDirForm({ onClose }: Props) {
   });
 
   const onMake: SubmitHandler<MakeDirFormSchema> = async (data) => {
-    try {
-      await make({
-        variables: {
-          key: `${path}/${data.name}`,
-        },
-      });
-      toast({
-        title: "作成しました.",
-        status: "success",
-        duration: 5000,
-      });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+    await make({
+      variables: {
+        key: `${path}/${data.name}`,
+      },
+    });
   };
 
   return (

--- a/web/src/features/storage/templates/RenameFileForm/RenameFileForm.tsx
+++ b/web/src/features/storage/templates/RenameFileForm/RenameFileForm.tsx
@@ -11,7 +11,6 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { RenameFileFormSchema, renameFileFormSchema } from "./schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { GetFilesDocument, useMoveFileMutation } from "@/gql/graphql";
-import { ApolloError } from "@apollo/client";
 import { useGetPath } from "../../hooks";
 
 type Props = {
@@ -24,7 +23,20 @@ export function RenameFileForm({ name, onClose }: Props) {
 
   const [rename] = useMoveFileMutation({
     onCompleted() {
+      toast({
+        title: "更新しました.",
+        status: "success",
+        duration: 5000,
+      });
       onClose();
+    },
+    onError(e) {
+      toast({
+        title: "エラーが発生しました.",
+        description: e.message,
+        status: "error",
+        duration: 5000,
+      });
     },
     refetchQueries: [GetFilesDocument],
   });
@@ -38,34 +50,18 @@ export function RenameFileForm({ name, onClose }: Props) {
   const toast = useToast();
 
   const onRename: SubmitHandler<RenameFileFormSchema> = async (data) => {
-    try {
-      await rename({
-        variables: {
-          input: [
-            {
-              key: `${path}/${name}`,
-              destination: `${path}/${data.name}${
-                name.includes(".") ? name.substring(name.lastIndexOf(".")) : ""
-              }`,
-            },
-          ],
-        },
-      });
-      toast({
-        title: "更新しました.",
-        status: "success",
-        duration: 5000,
-      });
-    } catch (e) {
-      if (e instanceof ApolloError) {
-        toast({
-          title: "エラーが発生しました.",
-          description: e.message,
-          status: "error",
-          duration: 5000,
-        });
-      }
-    }
+    await rename({
+      variables: {
+        input: [
+          {
+            key: `${path}/${name}`,
+            destination: `${path}/${data.name}${
+              name.includes(".") ? name.substring(name.lastIndexOf(".")) : ""
+            }`,
+          },
+        ],
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## issue
- close: #7 

## 変更内容
- mutation実行時のtoastをonCompleted, onErrorに移動
- useUpload, useDownloadの引数にonCompleted, onErrorを追加